### PR TITLE
Add ALL_SCOPES_URL variable displayed when providing a token creation link

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -7,6 +7,10 @@ module GitHub
   PR_ENV_KEY = "HOMEBREW_NEW_FORMULA_PULL_REQUEST_URL".freeze
   PR_ENV = ENV[PR_ENV_KEY]
 
+  ALL_SCOPES_URL = Formatter.url(
+    "https://github.com/settings/tokens/new?scopes=#{ALL_SCOPES.join(",")}&description=Homebrew",
+  ).freeze
+
   class Error < RuntimeError
     attr_reader :github_message
   end


### PR DESCRIPTION
I updated an older tap based on this repository's ruby files and noticed that this variable got removed as part of the updates to github.rb. I can't say if the original variable was removed from Brew's upstream api client but without this variable the scripts crash when it fails to find a valid token. 

When researching I found the original implementation that was removed as part of https://github.com/meetcleo/homebrew-cleo/commit/98053a010851fd7fe385ccf819b38c630ab4b399 which is equivalent to the url built in Homebrew's code https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/github/api.rb#L13-L15