### PR TITLE
Restore GitHub scope URL for token missing error

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -4,6 +4,14 @@ require "tempfile"
 module GitHub
   module_function
 
+  API_URL = "https://api.github.com".freeze
+
+  CREATE_GIST_SCOPES = ["gist"].freeze
+  CREATE_ISSUE_FORK_OR_PR_SCOPES = ["public_repo"].freeze
+  ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES).freeze
+  ALL_SCOPES_URL = Formatter.url(
+    "https://github.com/settings/tokens/new?scopes=#{ALL_SCOPES.join(",")}&description=Homebrew",
+  ).freeze
   PR_ENV_KEY = "HOMEBREW_NEW_FORMULA_PULL_REQUEST_URL".freeze
   PR_ENV = ENV[PR_ENV_KEY]
 


### PR DESCRIPTION
This reverts commit 98053a010851fd7fe385ccf819b38c630ab4b399.

When our token expires, we get:

    ==> Fetching meetcleo/cleo/cleo
    Error: uninitialized constant GitHub::ALL_SCOPES_URL
    /opt/homebrew/Library/Taps/meetcleo/homebrew-cleo/github.rb:138:in `api_credentials_error_message'

This should fix that.