### PR TITLE
fix: remove constants that are defined elsewhere

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -4,11 +4,6 @@ require "tempfile"
 module GitHub
   module_function
 
-  API_URL = "https://api.github.com".freeze
-
-  CREATE_GIST_SCOPES = ["gist"].freeze
-  CREATE_ISSUE_FORK_OR_PR_SCOPES = ["public_repo"].freeze
-  ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES).freeze
   ALL_SCOPES_URL = Formatter.url(
     "https://github.com/settings/tokens/new?scopes=#{ALL_SCOPES.join(",")}&description=Homebrew",
   ).freeze


### PR DESCRIPTION
Fixes these warnings

```
/usr/local/Homebrew/Library/Taps/meetcleo/homebrew-cleo/github.rb:7: warning: already initialized constant GitHub::API_URL
/usr/local/Homebrew/Library/Homebrew/utils/github/api.rb:19: warning: previous definition of API_URL was here
/usr/local/Homebrew/Library/Taps/meetcleo/homebrew-cleo/github.rb:9: warning: already initialized constant GitHub::CREATE_GIST_SCOPES
/usr/local/Homebrew/Library/Homebrew/utils/github/api.rb:27: warning: previous definition of CREATE_GIST_SCOPES was here
/usr/local/Homebrew/Library/Taps/meetcleo/homebrew-cleo/github.rb:10: warning: already initialized constant GitHub::CREATE_ISSUE_FORK_OR_PR_SCOPES
/usr/local/Homebrew/Library/Homebrew/utils/github/api.rb:28: warning: previous definition of CREATE_ISSUE_FORK_OR_PR_SCOPES was here
/usr/local/Homebrew/Library/Taps/meetcleo/homebrew-cleo/github.rb:11: warning: already initialized constant GitHub::ALL_SCOPES
/usr/local/Homebrew/Library/Homebrew/utils/github/api.rb:30: warning: previous definition of ALL_SCOPES was here
```